### PR TITLE
feat(golden): add update-claude-manifest.sh for reliable discovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,248 @@
+# Project Configuration
+
+> This file defines how Claude operates in this project. The baseline sections are universal.
+> Project-specific sections are appended below the bootstrap marker by `/bootstrap-claude`.
+
+## Development Philosophy
+
+- **Test-Driven Development (TDD):** Always write tests before implementation.
+  1. Write test file first with test cases for happy path and key error cases
+  2. Run tests — confirm new tests fail (red)
+  3. Implement the production code
+  4. Run tests — confirm all tests pass (green)
+  5. Refactor if needed
+- **Issue-Driven Workflow:** All work is tracked via the project's task tracker. Default: external issue tracker (see Issue Tracker section). Can be configured to use `tasks/todo.md` via `/bootstrap-claude`.
+- **Validate Before Claiming Completion:** Always run the project's validation command before committing, closing issues, or claiming work is done. Never skip validation.
+- **YAGNI:** Don't over-engineer. Only build what's needed now. Three similar lines of code is better than a premature abstraction.
+- **DRY within reason:** Avoid duplication, but don't create abstractions for one-time operations.
+- **Plan Before Building:** Enter plan mode for any task with 3+ steps or that involves architectural decisions. Write detailed specs upfront. If implementation hits unexpected complexity or repeated failures, stop and re-plan rather than pushing through.
+- **Challenge Your Work:** For non-trivial changes, pause and ask "is there a more elegant way?" before presenting. Skip for simple, obvious fixes. This is about implementation quality within scope, not scope expansion.
+- **Fix Bugs Autonomously:** When given a bug report with logs, errors, or failing tests, diagnose and resolve directly. Don't ask for hand-holding — read the evidence and fix it. Zero context switches required from the user.
+
+## Subagent Strategy
+
+- Use subagents to keep the main context window clean
+- Offload research, exploration, and parallel analysis to subagents
+- One focused task per subagent — don't overload
+- For complex problems, use multiple subagents rather than serial deep-dives
+- Subagent results feed back into the main thread as summarized findings
+
+## Session Start
+
+At the beginning of a fresh session on an existing project:
+1. Review `.claude/lessons.md` for patterns relevant to the current work
+2. Assess current state: run `/triage` or check the task tracking file
+3. Decide next action: continue interrupted work, pick up the next unblocked task, or plan new work
+
+## Continuous Improvement
+
+Maintain `.claude/lessons.md` with patterns learned from corrections and reviews.
+
+**When to update:**
+- After ANY user correction — capture what went wrong and the better approach
+- After `/review-pr` finds issues you introduced — reflect on why (see /review-pr § Self-Improvement)
+- Ruthlessly deduplicate — update existing entries rather than adding redundant ones
+
+**Format:**
+### [Pattern name]
+- **Wrong:** [what was done incorrectly]
+- **Right:** [the correct approach]
+- **Why:** [root cause or reasoning]
+
+## Issue Management
+
+All work is tracked via the project's task tracker with structured metadata.
+
+**Issue format:**
+```
+Title: {type}({scope}): {description}
+
+Types: feat | fix | refactor | docs | discovery | design | infra
+Scopes: defined per-project (see Project-Specific Configuration below)
+```
+
+**Issue body structure:**
+```
+## Summary
+[1-3 sentences describing what and why]
+
+## Dependencies
+- Blocked by: #NN — [reason]
+- Part of: #EPIC — [epic title]
+
+## Acceptance Criteria
+- [ ] [Specific, testable criterion]
+- [ ] [Another criterion]
+- [ ] Validation passes
+
+## Implementation Notes
+[Key files, approach, constraints]
+```
+
+**Dependency format (canonical — the ONLY recognized format):**
+```
+- Blocked by: #NN — reason
+```
+`#NN` uses the configured issue reference format (see Issue Tracker section). Other patterns (`depends on`, `waiting on`, `after #NN`) are NOT recognized by automation.
+
+## Issue Tracker
+
+> Configured by `/bootstrap-claude`. Default: GitHub Issues (`gh` CLI).
+> To use a different tracker (Jira, Linear, etc.), update this section
+> and the corresponding permissions in settings.local.json.
+
+**Tool:** GitHub CLI (`gh`)
+**Issue reference format:** `#NN` (e.g., `#53`)
+**Smart close syntax:** `Closes #NN`
+**Dependency format:** `- Blocked by: #NN — reason`
+
+### Operations Reference
+
+| Operation | Command |
+|-----------|---------|
+| List open issues | `gh issue list --state open --limit 200 --json number,title,body,labels,milestone,assignees` |
+| View issue | `gh issue view NUMBER --json number,title,body,labels,milestone,assignees` |
+| View issue body | `gh issue view NUMBER --json body --jq '.body'` |
+| Create issue | `gh issue create --title "TITLE" --body "BODY" --label "LABEL" [--assignee "USER"]` |
+| Edit issue body | `gh issue edit NUMBER --body "BODY"` |
+| Close issue | `gh issue close NUMBER` |
+| Comment on issue | `gh issue comment NUMBER --body "COMMENT"` |
+| Add label | `gh issue edit NUMBER --add-label "LABEL"` |
+| Remove label | `gh issue edit NUMBER --remove-label "LABEL"` |
+| Assign to milestone | `gh issue edit NUMBER --milestone "NAME"` |
+| Create milestone | `gh api repos/{owner}/{repo}/milestones --method POST -f title="NAME" -f state="open"` |
+| List milestones | `gh api repos/{owner}/{repo}/milestones` |
+| Check milestone progress | `gh api repos/{owner}/{repo}/milestones/{number}` |
+| Resolve current user | `gh api user --jq '.login'` |
+| List collaborators | `gh api repos/{owner}/{repo}/collaborators --jq '.[].login'` |
+
+## Commit Conventions
+
+Use conventional commits format:
+```
+type(scope): description
+
+- Bullet point 1
+- Bullet point 2
+
+Closes #NN
+```
+
+- Types: `feat`, `fix`, `refactor`, `docs`, `discovery`, `design`, `infra`
+- Include the smart close syntax (see Issue Tracker section) to auto-close the linked issue when merged
+- List key changes in the body
+- Never force-push or rewrite history on shared branches
+
+## PR Workflow
+
+- Every change gets a pull request
+- PRs link to issues via the smart close syntax (see Issue Tracker section) in the body
+- Feature branches target the release branch (if one exists), otherwise `main`
+- Branch naming: `{issue-number}-{slug}` (e.g., `53-add-auth-service`)
+- Use `/review-pr` before merging
+- One issue per feature branch — don't bundle unrelated work
+
+## Commands & Skills
+
+### Commands (slash commands)
+
+| Command | Purpose |
+|---------|---------|
+| `/wiggum` | Automated dev loop — pick next unblocked issue, implement, test, close, repeat |
+| `/triage` | Analyze backlog — dependency graph, readiness, label validation, prioritization |
+| `/create-issues` | Create issues from a plan — with tracking epic, dependencies, assignee resolution |
+| `/close-issue` | Validate acceptance criteria and close an issue with structured comment |
+| `/review-pr` | Review a PR against project quality standards |
+| `/validate-pr` | Validate a release PR — review, post findings, create issues for failures |
+| `/setup-release` | Plan a release — milestone, branch, implementation order |
+| `/bootstrap-claude` | Adapt Claude configuration to the current project's tech stack and conventions |
+| `/update-claude` | Pull golden set updates into a bootstrapped project |
+| `/improve-golden-set` | Extract generalized improvements from a project back into the golden set |
+| `/slim` | Audit the golden set for bloat and budget compliance — compress or remove content |
+
+### Skills (auto-invoked)
+
+| Skill | Purpose |
+|-------|---------|
+| `/shipit` | End-to-end autonomous delivery — from plan or spec to merged, deployed, and verified |
+| `/grill-me` | Stress-test a plan or design through relentless interview until shared understanding |
+| `/pomo` | Post-fix reflection — capture lessons learned and update project memory |
+| `/browser-automation` | Browser interaction — navigate, click, fill forms, screenshot, test web UIs |
+
+## Code Quality
+
+- Run the project validation command before every commit
+- Follow existing project conventions — don't introduce new patterns without discussion
+- No hardcoded values that should be configuration
+- Error handling at system boundaries
+- No committed credentials, secrets, or .env files
+- Tests exist for new functionality
+
+## Pre-existing Failures
+
+If a test file you did NOT modify is failing, the failure is pre-existing. Create an issue for it (if one doesn't already exist) using the **create issue** operation (CLAUDE.md § Issue Tracker) and continue — do not silently work around it.
+
+<!-- bootstrap-claude: project-specific below -->
+<!-- Everything below this line is generated by /bootstrap-claude for this specific project -->
+<!-- To regenerate: delete everything below this marker and run /bootstrap-claude again -->
+
+## Project Overview
+
+**Project:** Claude Bootstrapping
+**Architecture:** Configuration/documentation repository — a portable "golden set" of Claude Code configuration with a deployment script
+**Tech Stack:** Bash, Markdown
+
+## How to Build / Test / Run
+
+| Command | Purpose |
+|---------|---------|
+| `./deploy.sh /path/to/project` | Deploy the golden set into a target project |
+| `bash -n deploy.sh` | Syntax-check the deploy script |
+
+**Validation command:** `bash -n deploy.sh` — this is the hard gate for all workflow commands. Note: this project has no compiled code or test suite; validation is limited to shell syntax checking.
+
+## Project Structure
+
+| File/Directory | Purpose |
+|---------------|---------|
+| `golden/` | The portable golden set — all baseline configuration lives here |
+| `golden/CLAUDE.md` | Master baseline CLAUDE.md (universal sections only) |
+| `golden/.claude/commands/` | Workflow command definitions (9 commands) |
+| `golden/.claude/agents/` | Subagent definitions (code-reviewer) |
+| `golden/.claude/settings.local.json` | Baseline pre-approved tool permissions |
+| `golden/.mcp.json` | Baseline MCP server config |
+| `deploy.sh` | Script to copy golden set into target projects |
+| `docs/plans/` | Design documents and implementation plans |
+| `images/` | Workflow illustration |
+
+## Issue Scopes
+
+Scopes for commit messages and issue titles:
+- `golden`: Changes to the golden set (commands, agents, CLAUDE.md baseline, settings, MCP config)
+- `deploy`: Changes to deploy.sh or deployment mechanism
+- `docs`: Documentation changes (README, design docs, plans)
+
+## Architecture Rules
+
+- **Golden set is the source of truth.** All portable configuration lives in `golden/`. The root-level CLAUDE.md, .claude/, and .mcp.json are deployed copies — edit `golden/` to make changes, then re-deploy.
+- **Commands must be project-agnostic.** Commands in `golden/.claude/commands/` must work for any tech stack. Never hardcode project-specific file paths, framework names, or tool names.
+- **Bootstrap marker discipline.** Content above the marker in CLAUDE.md is baseline (universal). Content below is project-specific (generated by /bootstrap-claude). Never mix the two.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `golden/CLAUDE.md` | Master baseline — edit this, not root CLAUDE.md |
+| `golden/.claude/commands/bootstrap-claude.md` | The project adapter command (562 lines) |
+| `golden/.claude/commands/wiggum.md` | Autonomous dev loop |
+| `golden/.claude/commands/improve-golden-set.md` | Extract improvements from projects |
+| `golden/.claude/commands/update-claude.md` | Pull golden set updates into projects |
+| `deploy.sh` | Deployment script |
+
+## Task Tracker
+
+All work is tracked in `tasks/todo.md`.
+
+**Task reference format:** `T-NN` (e.g., `T-1`)
+**Commit reference:** `Completes T-NN`
+**Dependency format:** `- Blocked by: T-NN — reason`

--- a/docs/superpowers/specs/2026-04-03-update-claude-manifest-design.md
+++ b/docs/superpowers/specs/2026-04-03-update-claude-manifest-design.md
@@ -1,0 +1,68 @@
+# Design: update-claude-manifest.sh
+
+## Problem
+
+When `/update-claude` runs in a bootstrapped project, Claude (the AI) does its own file discovery to compare golden set contents against the project. This is unreliable — Claude may miss directories (especially skills), fail to glob correctly, or skip categories entirely. The user reported that new skills weren't found even though the command attempted to look.
+
+## Solution
+
+A standalone shell script (`update-claude-manifest.sh`) that produces a structured text manifest comparing golden set contents against a target project. The `/update-claude` command runs this script first and uses its output as the authoritative inventory for all subsequent diff steps.
+
+## Script: `update-claude-manifest.sh`
+
+**Location:** Repository root (next to `deploy.sh`)
+
+**Usage:** `bash <golden-path>/update-claude-manifest.sh <golden-path> <project-path>`
+
+**Behavior:**
+- Lists files/directories in each category for both golden and project
+- Computes `new` items (in golden, not in project) per category
+- Outputs structured text to stdout
+- Exits 0 always (informational only, no failure states)
+- No content diffing — presence/absence only
+
+**Categories** (matching update-claude steps):
+1. CLAUDE.md — exists/missing
+2. COMMANDS — `*.md` files in `.claude/commands/`
+3. AGENTS — `*.md` files in `.claude/agents/`
+4. SKILLS — subdirectories in `.claude/skills/` (by directory name, not file)
+5. AGENT_DOCS — `*.md` files in `agent_docs/`
+6. SETTINGS — `.claude/settings.local.json` exists/missing
+7. MCP — `.mcp.json` exists/missing
+8. GOVERNANCE — `BUDGETS.md`, `CHANGELOG.md` at root
+
+**Output format:**
+```
+=== CATEGORY ===
+golden: item1 item2 item3
+project: item1 item2
+new: item3
+```
+
+For single-file categories (CLAUDE.md, SETTINGS, MCP):
+```
+=== CLAUDE.md ===
+golden: exists
+project: exists
+```
+
+## Changes to `update-claude.md`
+
+Insert a new step between current steps 1 (validate golden set path) and 2 (validate current project):
+
+> **Step 1.5: Run discovery manifest**
+>
+> Run the manifest script and capture its output:
+> ```
+> bash <golden-path>/update-claude-manifest.sh <golden-path> .
+> ```
+> Use this output as the authoritative file inventory for all subsequent steps. Do not independently glob or list files — trust the manifest.
+
+Update steps 3-11 to reference the manifest output rather than doing their own file discovery. The steps still do content comparison (reading and diffing file contents), but they use the manifest to know which files to compare.
+
+## What this does NOT change
+
+- The approval flow (user approves each change) stays the same
+- Content diffing (reading files, comparing text) stays Claude-driven
+- The step structure of update-claude stays the same (just adds 1.5 and references manifest)
+- deploy.sh is untouched

--- a/golden/.claude/commands/update-claude.md
+++ b/golden/.claude/commands/update-claude.md
@@ -28,7 +28,17 @@ Confirm the golden set path:
 
 If any check fails, report the specific problem and stop.
 
-### 2. Validate the current project
+### 2. Run discovery manifest
+
+Run the manifest script to get a deterministic inventory of golden vs project contents:
+
+```bash
+bash <golden-path>/update-claude-manifest.sh <golden-path> .
+```
+
+This produces a structured listing of all categories (CLAUDE.md, commands, agents, skills, agent_docs, settings, MCP, governance) showing what exists in golden, what exists in the project, and what's new. **Use this output as the authoritative file inventory for all subsequent diff steps.** Do not independently glob or list directories — trust the manifest.
+
+### 3. Validate the current project
 
 Confirm the current project:
 - Has `CLAUDE.md` at the project root
@@ -37,7 +47,7 @@ Confirm the current project:
 
 If any check fails, report the specific problem and stop.
 
-### 3. Diff CLAUDE.md baseline
+### 4. Diff CLAUDE.md baseline
 
 Extract the project's baseline — everything above the bootstrap marker (`<!-- bootstrap-claude: project-specific below -->`). Compare it against `golden/CLAUDE.md`.
 
@@ -47,9 +57,9 @@ Classify the baseline as one of:
 - **Project modified:** Project changed its baseline, golden has the old version
 - **Diverged:** Both sides differ from each other
 
-### 4. Diff commands
+### 5. Diff commands
 
-For each file in `golden/.claude/commands/*.md`, check whether a matching file exists in the project's `.claude/commands/`:
+Using the COMMANDS section from the manifest, for each file listed under `golden:`, check whether it also appears under `project:` (files listed under `new:` are definitely new):
 
 - **New:** File exists in golden but not in the project
 - **Unchanged:** File is identical in both
@@ -61,9 +71,9 @@ Ignore project commands that do not exist in the golden set — those are projec
 
 **Note:** Without version tracking, distinguishing "Golden updated" from "Project modified" may not always be possible. When in doubt, classify as **Diverged** and let the user decide.
 
-### 5. Diff agent_docs
+### 6. Diff agent_docs
 
-For each file in `golden/agent_docs/*.md`, check whether a matching file exists in the project's `agent_docs/`:
+Using the AGENT_DOCS section from the manifest, for each file listed under `golden:`, check whether it also appears under `project:`:
 
 - **New:** File exists in golden but not in the project
 - **Unchanged:** File is identical in both
@@ -73,9 +83,9 @@ For each file in `golden/agent_docs/*.md`, check whether a matching file exists 
 
 Ignore project `agent_docs/` files that do not exist in the golden set — those are project-specific reference docs and must be left alone.
 
-### 6. Diff agents
+### 7. Diff agents
 
-For each file in `golden/.claude/agents/*.md`, check whether a matching file exists in the project's `.claude/agents/`:
+Using the AGENTS section from the manifest, for each file listed under `golden:`, check whether it also appears under `project:`:
 
 Apply the same classification as commands: **New**, **Unchanged**, **Golden updated**, **Project modified**, **Diverged**.
 
@@ -83,9 +93,9 @@ For agents with a bootstrap marker (`<!-- bootstrap-claude: project-specific che
 
 Ignore project agents that do not exist in the golden set.
 
-### 7. Diff skills
+### 8. Diff skills
 
-**First**, list all skill directories in `golden/.claude/skills/` (excluding `.DS_Store` and hidden files). Each subdirectory is a skill. **Then**, for each golden skill, check whether a matching directory exists in the project's `.claude/skills/`. Compare the `SKILL.md` files within each:
+Using the SKILLS section from the manifest, for each skill listed under `golden:`, check whether it also appears under `project:`. For skills that exist in both, compare the `SKILL.md` files within each:
 
 - **New:** Skill directory exists in golden but not in the project
 - **Unchanged:** `SKILL.md` is identical in both
@@ -97,7 +107,7 @@ If the project has no `.claude/skills/` directory at all, classify ALL golden sk
 
 Ignore project skills that do not exist in the golden set — those are project-specific and must be left alone.
 
-### 8. Diff settings.local.json
+### 9. Diff settings.local.json
 
 Parse the `allow` arrays from both `golden/.claude/settings.local.json` and the project's `.claude/settings.local.json`.
 
@@ -105,7 +115,7 @@ Identify permissions present in the golden set but absent from the project — t
 
 Never flag project-specific permissions for removal. Project permissions that are not in the golden set are project-specific and must be left alone.
 
-### 9. Diff .mcp.json
+### 10. Diff .mcp.json
 
 Compare server configurations between `golden/.mcp.json` and the project's `.mcp.json`.
 
@@ -113,7 +123,7 @@ Identify new servers in the golden set that are not in the project. Identify ser
 
 Never flag project-specific servers for removal.
 
-### 10. Diff governance files
+### 11. Diff governance files
 
 Compare `golden/BUDGETS.md` against the project's `BUDGETS.md` (if it exists):
 - If the project has no `BUDGETS.md`, flag as **New** — recommend adding
@@ -121,13 +131,13 @@ Compare `golden/BUDGETS.md` against the project's `BUDGETS.md` (if it exists):
 
 Similarly, compare `golden/CHANGELOG.md` against the project's `CHANGELOG.md`.
 
-### 11. Check for removed golden items
+### 12. Check for removed golden items
 
 Check for files that exist in the project's `.claude/commands/`, `.claude/agents/`, or `.claude/skills/` that match golden set naming patterns but no longer exist in the golden set. These are items that were previously deployed from golden but have since been removed from it.
 
 Skip project-specific commands generated by `/bootstrap-claude` (e.g., `add-endpoint.md`, `add-component.md`, `add-pipeline-step.md`, `update-docs.md`) — these were never part of the golden set. Only flag files whose names suggest golden set origin but are no longer present in the golden set.
 
-### 12. Assess results
+### 13. Assess results
 
 If everything is identical across all categories, report:
 
@@ -137,7 +147,7 @@ Already up to date. No golden set changes to apply.
 
 Stop here if nothing changed.
 
-### 13. Present changes for approval
+### 14. Present changes for approval
 
 Group findings by type and present each change individually for user approval.
 
@@ -163,7 +173,7 @@ Group findings by type and present each change individually for user approval.
 
 Wait for the user to approve or reject each change before proceeding.
 
-### 14. Apply approved changes
+### 15. Apply approved changes
 
 For each approved change:
 
@@ -191,7 +201,7 @@ For each approved change:
 
 **Removed items (approved for removal):** Delete the file from the project.
 
-### 15. Post-Application Budget Audit
+### 16. Post-Application Budget Audit
 
 After applying all changes, re-measure the project's CLAUDE.md against `BUDGETS.md`:
 
@@ -202,7 +212,7 @@ After applying all changes, re-measure the project's CLAUDE.md against `BUDGETS.
 
    "Budget exceeded: CLAUDE.md baseline is now NN lines (budget: 60). Consider running /slim to identify compression or relocation opportunities."
 
-### 16. Summary
+### 17. Summary
 
 Present a summary of all changes applied:
 

--- a/golden/CLAUDE.md
+++ b/golden/CLAUDE.md
@@ -45,6 +45,33 @@ Never force-push or rewrite history on shared branches.
 
 If a test file you did NOT modify is failing, create an issue and continue. Do not silently work around it.
 
+## Commands & Skills
+
+### Commands (slash commands)
+
+| Command | Purpose |
+|---------|---------|
+| `/wiggum` | Automated dev loop — pick next unblocked issue, implement, test, close, repeat |
+| `/triage` | Analyze backlog — dependency graph, readiness, label validation, prioritization |
+| `/create-issues` | Create issues from a plan — with tracking epic, dependencies, assignee resolution |
+| `/close-issue` | Validate acceptance criteria and close an issue with structured comment |
+| `/review-pr` | Review a PR against project quality standards |
+| `/validate-pr` | Validate a release PR — review, post findings, create issues for failures |
+| `/setup-release` | Plan a release — milestone, branch, implementation order |
+| `/bootstrap-claude` | Adapt Claude configuration to the current project's tech stack and conventions |
+| `/update-claude` | Pull golden set updates into a bootstrapped project |
+| `/improve-golden-set` | Extract generalized improvements from a project back into the golden set |
+| `/slim` | Audit the golden set for bloat and budget compliance — compress or remove content |
+
+### Skills (auto-invoked)
+
+| Skill | Purpose |
+|-------|---------|
+| `/shipit` | End-to-end autonomous delivery — from plan or spec to merged, deployed, and verified |
+| `/grill-me` | Stress-test a plan or design through relentless interview until shared understanding |
+| `/pomo` | Post-fix reflection — capture lessons learned and update project memory |
+| `/browser-automation` | Browser interaction — navigate, click, fill forms, screenshot, test web UIs |
+
 ## Reference Docs
 
 | Doc | When to read |

--- a/update-claude-manifest.sh
+++ b/update-claude-manifest.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# update-claude-manifest.sh — Produce a structured manifest comparing golden set vs project
+#
+# Usage:
+#   bash update-claude-manifest.sh <golden-repo-path> <project-path>
+#
+# Output: structured text listing files in each category for both golden and project,
+# plus items that are new (in golden but not in project).
+
+GOLDEN_REPO="${1:-}"
+PROJECT="${2:-}"
+
+if [ -z "$GOLDEN_REPO" ] || [ -z "$PROJECT" ]; then
+  echo "Usage: bash update-claude-manifest.sh <golden-repo-path> <project-path>"
+  exit 1
+fi
+
+GOLDEN="$GOLDEN_REPO/golden"
+
+if [ ! -d "$GOLDEN" ]; then
+  echo "Error: golden/ directory not found at $GOLDEN"
+  exit 1
+fi
+
+# Helper: list *.md filenames (basename only) in a directory, one per line, sorted
+list_md() {
+  local dir="$1"
+  if [ -d "$dir" ]; then
+    ls -1 "$dir"/*.md 2>/dev/null | xargs -I{} basename {} | sort
+  fi
+}
+
+# Helper: list subdirectory names in a directory, excluding hidden files and .DS_Store
+list_subdirs() {
+  local dir="$1"
+  if [ -d "$dir" ]; then
+    ls -1 "$dir" 2>/dev/null | grep -v '^\.' | grep -v '.DS_Store' | sort
+  fi
+}
+
+# Helper: join lines into a space-separated string
+join_line() {
+  paste -sd' ' - 2>/dev/null
+}
+
+# Helper: compute items in list A but not in list B (both newline-separated)
+new_items() {
+  local a="$1"
+  local b="$2"
+  if [ -z "$a" ]; then return; fi
+  if [ -z "$b" ]; then echo "$a" | join_line; return; fi
+  comm -23 <(echo "$a") <(echo "$b") 2>/dev/null | join_line
+}
+
+# --- CLAUDE.md ---
+echo "=== CLAUDE.md ==="
+echo -n "golden: "; [ -f "$GOLDEN/CLAUDE.md" ] && echo "exists" || echo "missing"
+echo -n "project: "; [ -f "$PROJECT/CLAUDE.md" ] && echo "exists" || echo "missing"
+echo ""
+
+# --- COMMANDS ---
+echo "=== COMMANDS ==="
+golden_cmds=$(list_md "$GOLDEN/.claude/commands")
+project_cmds=$(list_md "$PROJECT/.claude/commands")
+echo "golden: $(echo "$golden_cmds" | join_line)"
+echo "project: $(echo "$project_cmds" | join_line)"
+echo "new: $(new_items "$golden_cmds" "$project_cmds")"
+echo ""
+
+# --- AGENTS ---
+echo "=== AGENTS ==="
+golden_agents=$(list_md "$GOLDEN/.claude/agents")
+project_agents=$(list_md "$PROJECT/.claude/agents")
+echo "golden: $(echo "$golden_agents" | join_line)"
+echo "project: $(echo "$project_agents" | join_line)"
+echo "new: $(new_items "$golden_agents" "$project_agents")"
+echo ""
+
+# --- SKILLS ---
+echo "=== SKILLS ==="
+golden_skills=$(list_subdirs "$GOLDEN/.claude/skills")
+project_skills=$(list_subdirs "$PROJECT/.claude/skills")
+echo "golden: $(echo "$golden_skills" | join_line)"
+echo "project: $(echo "$project_skills" | join_line)"
+echo "new: $(new_items "$golden_skills" "$project_skills")"
+echo ""
+
+# --- AGENT_DOCS ---
+echo "=== AGENT_DOCS ==="
+golden_docs=$(list_md "$GOLDEN/agent_docs")
+project_docs=$(list_md "$PROJECT/agent_docs")
+echo "golden: $(echo "$golden_docs" | join_line)"
+echo "project: $(echo "$project_docs" | join_line)"
+echo "new: $(new_items "$golden_docs" "$project_docs")"
+echo ""
+
+# --- SETTINGS ---
+echo "=== SETTINGS ==="
+echo -n "golden: "; [ -f "$GOLDEN/.claude/settings.local.json" ] && echo "exists" || echo "missing"
+echo -n "project: "; [ -f "$PROJECT/.claude/settings.local.json" ] && echo "exists" || echo "missing"
+echo ""
+
+# --- MCP ---
+echo "=== MCP ==="
+echo -n "golden: "; [ -f "$GOLDEN/.mcp.json" ] && echo "exists" || echo "missing"
+echo -n "project: "; [ -f "$PROJECT/.mcp.json" ] && echo "exists" || echo "missing"
+echo ""
+
+# --- GOVERNANCE ---
+echo "=== GOVERNANCE ==="
+golden_gov=""
+project_gov=""
+for file in BUDGETS.md CHANGELOG.md; do
+  [ -f "$GOLDEN/$file" ] && golden_gov="$golden_gov $file"
+  [ -f "$PROJECT/$file" ] && project_gov="$project_gov $file"
+done
+golden_gov=$(echo "$golden_gov" | xargs)
+project_gov=$(echo "$project_gov" | xargs)
+echo "golden: $golden_gov"
+echo "project: $project_gov"
+new_gov=""
+for file in BUDGETS.md CHANGELOG.md; do
+  if [ -f "$GOLDEN/$file" ] && [ ! -f "$PROJECT/$file" ]; then
+    new_gov="$new_gov $file"
+  fi
+done
+echo "new: $(echo "$new_gov" | xargs)"
+echo ""


### PR DESCRIPTION
## Summary

- Adds `update-claude-manifest.sh` — a standalone shell script that produces a structured manifest comparing golden set contents against a target project
- Updates `/update-claude` to run the manifest as step 2, with all subsequent diff steps referencing its output instead of doing independent file discovery
- Adds comprehensive Commands & Skills table to golden CLAUDE.md (was missing `/validate-pr`, `/slim`, and all 4 skills)

## Problem

When `/update-claude` runs in a bootstrapped project, Claude does its own file discovery via tool calls. This is unreliable — new skills weren't found even though the command attempted to look. A deterministic shell script makes discovery reliable.

## Test plan

- [ ] `bash -n update-claude-manifest.sh` passes
- [ ] `bash -n deploy.sh` passes
- [ ] `bash update-claude-manifest.sh . .` produces correct manifest against this repo
- [ ] Run `/update-claude` in a bootstrapped project and verify skills are discovered

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `/update-claude` workflow to depend on a new shell-based inventory step; edge cases in the manifest script (filesystem quirks, spaces, missing dirs) could affect what updates are detected and applied.
> 
> **Overview**
> Adds `update-claude-manifest.sh`, a new root-level shell script that emits a structured manifest of **golden vs project** inventory across CLAUDE.md, commands, agents, skills, agent docs, settings, MCP, and governance files.
> 
> Updates `/update-claude` to run this manifest early and to use its output as the authoritative source for what to diff, instead of doing ad-hoc file discovery during later steps.
> 
> Expands the golden `CLAUDE.md` baseline (and the deployed root `CLAUDE.md` in this repo) with a **Commands & Skills** reference table, and adds a short design spec documenting the manifest approach.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6058d805ebb2518c71df43548e7324ab2186370. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->